### PR TITLE
fix: replace inline worker with url + vite serve

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-ai-toolkit",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-ai-toolkit",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "ISC",
       "dependencies": {
         "@huggingface/transformers": "^3.0.0-alpha.14",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "vite build",
-    "start": "npm run build && npx httpster test.html"
+    "start": "npm run build && npx vite serve"
   },
   "author": "",
   "license": "ISC",

--- a/src/services/ocr/ocr.ts
+++ b/src/services/ocr/ocr.ts
@@ -1,12 +1,9 @@
 let ocrWorker: Worker;
 
-// @ts-ignore
-import OCRWorker from './ocr-worker?worker&inline';
-
 export async function loadOCR(model: string): Promise<void> {
     return new Promise(async (resolve) => {
         if (!ocrWorker) {
-            ocrWorker = new OCRWorker();
+            ocrWorker = new Worker(new URL('./ocr-worker.ts', import.meta.url), { type: 'module' });
         }
 
         ocrWorker.onmessage = async (e) => {

--- a/src/services/speech-recognition/whisper-ai.ts
+++ b/src/services/speech-recognition/whisper-ai.ts
@@ -1,11 +1,10 @@
 let whisperWorker: Worker;
 
-// @ts-ignore
-import WhisperWorker from './worker?worker&inline'
-
 export async function loadTranscriber(model: string = "Xenova/whisper-tiny", timestamps: boolean, language: string): Promise<void> {
     return new Promise(async (resolve) => {
-        whisperWorker = new WhisperWorker();
+        if (!whisperWorker) {
+            whisperWorker = new Worker(new URL('./worker.ts', import.meta.url), { type: 'module' });
+        }
 
         whisperWorker.onmessage = async (e) => {
             if (e.data.type === "loaded") {

--- a/src/services/summarization/summarization.ts
+++ b/src/services/summarization/summarization.ts
@@ -1,12 +1,9 @@
 let summaryWorker: Worker;
 
-// @ts-ignore
-import SummaryWorker from './summary-worker?worker&inline';
-
 export async function loadSummarizer(model: string = "Xenova/distilbart-cnn-6-6"): Promise<void> {
     return new Promise(async (resolve) => {
         if (!summaryWorker) {
-            summaryWorker = new SummaryWorker();
+            summaryWorker = new Worker(new URL('./summary-worker.ts', import.meta.url), { type: 'module' });
         }
 
         summaryWorker.onmessage = async (e) => {

--- a/src/services/text-to-speech/text-to-speech.ts
+++ b/src/services/text-to-speech/text-to-speech.ts
@@ -1,12 +1,9 @@
 let ttsWorker: Worker;
 
-// @ts-ignore
-import TTSWorker from './tts-worker?worker&inline';
-
 export async function loadTTS(model: string = "Xenova/mms-tts-eng"): Promise<void> {
     return new Promise(async (resolve) => {
         if (!ttsWorker) {
-          ttsWorker = new TTSWorker();
+          ttsWorker = new Worker(new URL('./tts-worker.ts', import.meta.url), { type: 'module' });
         }
 
         ttsWorker.onmessage = async (e) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,9 +12,9 @@ export default defineConfig({
       target: "es2022",
     }
   },
+  publicDir: 'dist',
   build: {
     sourcemap: false,
-    assetsDir: "code",
     cssMinify: true,
     target: "esnext",
     lib: {
@@ -27,6 +27,9 @@ export default defineConfig({
         format: "es",
       },
     }
+  },
+  server: {
+    open: '/test.html',
   },
   plugins: [
     dts({


### PR DESCRIPTION
Relates to #5 

The main issue seems to happen when using the new `@huggingface/transformers` + inline worker, I found an workaround to keep using the alpha release which includes going back to url import following some suggestions here: https://github.com/vitejs/vite/issues/7352

I couldn't make it load correctly when using `httpster`, the paths were wrong, but using the `vite serve` seems to make it work, let me know if you are agains't.

![image](https://github.com/user-attachments/assets/6b76d551-3012-495b-9508-729871b30788)

![image](https://github.com/user-attachments/assets/fbd67363-04ba-44cf-b217-9f49dd9f991c)
